### PR TITLE
Fix parse_environment task_config

### DIFF
--- a/qcengine/config.py
+++ b/qcengine/config.py
@@ -293,7 +293,7 @@ def get_config(*, hostname: Optional[str] = None, task_config: Dict[str, Any] = 
         task_config = {}
 
     task_config_env = read_qcengine_task_environment()
-    task_config = {**task_config_env, **task_config}
+    task_config = {**task_config_env, **parse_environment(task_config)}
 
     config = {}
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Description
<!-- Provide a brief description of the PR's purpose here. -->
Fixed a minor bug introduced at #400

Expected behavior
```python
>>> os.environ["SCRATCH"] = "/my_scratch"
>>> qcng.get_config(task_config={"scratch_directory": "$SCRATCH"})
<JobConfig ncores=2 memory=2.506 scratch_directory='/my_scratch'>
```

observed behavior
```python
>>> os.environ["SCRATCH"] = "/my_scratch"
>>> qcng.get_config(task_config={"scratch_directory": "$SCRATCH"})
<JobConfig ncores=2 memory=2.506 scratch_directory='$SCRATCH'>
```

## Changelog description
<!-- Provide a brief single sentence for the changelog. -->

## Status
<!-- Please `pip install .[lint]; make format` in the base folder. -->
- [x] Code base linted
- [x] Ready to go
